### PR TITLE
Pyaml 3.13 released fix pip3 issue on mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyyaml==3.12
+pyyaml==3.13
 rarfile==3.0
 requests==2.19.1


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/issues/126

This does not require additional work around on OSX.